### PR TITLE
Issue #1411: Hide BPI workflow field from node display

### DIFF
--- a/bpi_features/bpi_features.features.field_instance.inc
+++ b/bpi_features/bpi_features.features.field_instance.inc
@@ -19,10 +19,9 @@ function bpi_features_field_default_field_instances() {
     'display' => array(
       'default' => array(
         'label' => 'above',
-        'module' => 'list',
         'settings' => array(),
-        'type' => 'list_default',
-        'weight' => 11,
+        'type' => 'hidden',
+        'weight' => 9,
       ),
       'search_result' => array(
         'label' => 'above',


### PR DESCRIPTION
End users should not see the workflow state of a node. Editorial users can still use the Node Workflow tab.
